### PR TITLE
Fix `curlopt_ssl_verifypeer` option configuration

### DIFF
--- a/lib/CoinGate.php
+++ b/lib/CoinGate.php
@@ -21,6 +21,9 @@ class CoinGate
 
         if (isset($authentication['user_agent']))
             self::$user_agent = $authentication['user_agent'];
+        
+        if (isset($authentication['curlopt_ssl_verifypeer'])) 
+            self::$curlopt_ssl_verifypeer = $authentication['curlopt_ssl_verifypeer'];
     }
 
     public static function testConnection($authentication = array())


### PR DESCRIPTION
Using `curlopt_ssl_verifypeer` options via configuration as it described in https://github.com/coingate/coingate-php#setting-default-authentication has not any effect.
This pull-request fix this issue.