### PR TITLE
Fix checkout resource PHPDoc property typo

### DIFF
--- a/lib/Resources/Checkout.php
+++ b/lib/Resources/Checkout.php
@@ -7,7 +7,7 @@ namespace CoinGate\Resources;
  *
  * @property string $pay_currency
  * @property string $pay_amount
- * @property string $expired_at
+ * @property string $expire_at
  * @property string $payment_address
  */
 class Checkout extends Order


### PR DESCRIPTION
Probably a accidental typo

Actual checkout resource response:
```
{#424
  +"id": 881712
  +"status": "pending"
  +"do_not_convert": true
  +"price_currency": "EUR"
  +"price_amount": "2150.84"
  +"pay_currency": "BTC"
  +"pay_amount": "0.0500000"
  +"lightning_network": false
  +"receive_currency": "BTC"
  +"receive_amount": "0.050747"
  +"created_at": "2022-04-02T11:56:24+00:00"
  +"expire_at": "2022-04-02T12:16:25+00:00"
  +"payment_address": "XXX"
  +"order_id": "34ef9cea-a479-4a97-baf4-b32c51cecc3f"
  +"payment_url": "XXX"
  +"underpaid_amount": "0.0500000"
  +"overpaid_amount": "0"
  +"is_refundable": false
}
```